### PR TITLE
Remove trailing ':' after the URL when an audit vulnerability is found

### DIFF
--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -119,7 +119,7 @@ export default function audit(yargs: Argv): Argv {
 
       // Display vulnerabilities
       vulnerabilities.forEach(([, { title, severity, url, findings }]) => {
-        console.log(` - ${url}: ${title} (${severity.toUpperCase()})`)
+        console.log(` - ${url} ${title} (${severity.toUpperCase()})`)
         findings.forEach(({ version, paths }) => {
           paths.forEach(path => {
             console.log(`    - ${path.replace(/>/g, ' > ')}@${version}`)


### PR DESCRIPTION
Fixes #2
